### PR TITLE
Update README badges to use Azure pipelines on EBU remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # AI Benchmarking STT
 
-[![Build Status](https://travis-ci.com/MikeSmithEU/ai-benchmarking-stt.svg?branch=master)](https://travis-ci.com/MikeSmithEU/ai-benchmarking-stt)  [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Build Status](https://dev.azure.com/danielthepope/ai-benchmarking-stt/_apis/build/status/ebu.ai-benchmarking-stt?branchName=master)](https://dev.azure.com/danielthepope/ai-benchmarking-stt/_build/latest?definitionId=3&branchName=master) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 
 # AI Benchmarking STT
 
-[![Build Status](https://dev.azure.com/danielthepope/ai-benchmarking-stt/_apis/build/status/ebu.ai-benchmarking-stt?branchName=master)](https://dev.azure.com/danielthepope/ai-benchmarking-stt/_build/latest?definitionId=3&branchName=master) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Azure Build](https://img.shields.io/azure-devops/build/danielthepope/ai-benchmarking-stt/3.svg?logo=azure-devops)](https://dev.azure.com/danielthepope/ai-benchmarking-stt/_build/latest?definitionId=3&branchName=master)
+[![Azure Tests](https://img.shields.io/azure-devops/tests/danielthepope/ai-benchmarking-stt/3.svg?logo=azure-devops)](https://dev.azure.com/danielthepope/ai-benchmarking-stt/_build/latest?definitionId=3&branchName=master)
+[![License: MIT](https://img.shields.io/github/license/ebu/ai-benchmarking-stt.svg)](https://opensource.org/licenses/MIT)
 
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,8 +1,8 @@
 Welcome to BenchmarkSTT's documentation!
 ========================================
 
-.. image:: https://travis-ci.com/MikeSmithEU/ai-benchmarking-stt.svg?branch=master
-    :target: https://travis-ci.com/MikeSmithEU/ai-benchmarking-stt
+.. image:: https://dev.azure.com/danielthepope/ai-benchmarking-stt/_apis/build/status/ebu.ai-benchmarking-stt?branchName=master
+    :target: https://dev.azure.com/danielthepope/ai-benchmarking-stt/_build/latest?definitionId=3&branchName=master
 
 .. image:: https://img.shields.io/badge/License-MIT-yellow.svg
     :target: https://opensource.org/licenses/MIT

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,10 +1,10 @@
 Welcome to BenchmarkSTT's documentation!
 ========================================
 
-.. image:: https://dev.azure.com/danielthepope/ai-benchmarking-stt/_apis/build/status/ebu.ai-benchmarking-stt?branchName=master
+.. image:: https://img.shields.io/azure-devops/build/danielthepope/ai-benchmarking-stt/3.svg?logo=azure-devops
     :target: https://dev.azure.com/danielthepope/ai-benchmarking-stt/_build/latest?definitionId=3&branchName=master
 
-.. image:: https://img.shields.io/badge/License-MIT-yellow.svg
+.. image:: https://img.shields.io/github/license/ebu/ai-benchmarking-stt.svg
     :target: https://opensource.org/licenses/MIT
 
 


### PR DESCRIPTION
Updated so that the badges in the README and index.rst point to the correct repository. I'm aware that the Azure Pipelines URL looks like it's pointing to my fork of the project - apparently `definitionId=3` is what points it to the EBU version instead.

I haven't removed .travis.yml, nor have I updated references to @MikeSmithEU's fork in the documentation. We can do that another time.