### PR TITLE
Fix missing documentation

### DIFF
--- a/src/benchmarkstt/cli.py
+++ b/src/benchmarkstt/cli.py
@@ -166,6 +166,11 @@ def main():
     exit(0)
 
 
+def main_parser():
+    with main_parser_context() as parser:
+        return parser
+
+
 def tools_parser():
     name = 'benchmarkstt-tools'
     desc = 'Some additional helpful tools'


### PR DESCRIPTION
Quick fix to fix missing documentation of `benchmarkstt` command line.