### PR TITLE
Levenshtein

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,8 @@ setup(
         'test': [
             "pytest==4.2.0",
             "pycodestyle==2.5.0",
-            "pytest-cov==2.5.1"
+            "pytest-cov==2.5.1",
+            "attrs==19.1.0"
         ]
     },
     platforms='any',

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(
         'jsonrpcserver>=4.0.1',
         'gunicorn>=19.9.0',
         'docutils>=0.14',
+        'editdistance>=0.5.3',
     ],
     extras_require={
         'test': [

--- a/src/benchmarkstt/metrics/core.py
+++ b/src/benchmarkstt/metrics/core.py
@@ -5,6 +5,7 @@ from benchmarkstt.diff.formatter import format_diff
 from benchmarkstt.metrics import Base
 from collections import namedtuple
 # from benchmarkstt.modules import LoadObjectProxy
+import editdistance
 
 logger = logging.getLogger(__name__)
 
@@ -118,6 +119,31 @@ class WER(Base):
             return 1
         return changes / total_ref
 
+
+class Levenshtein(Base):
+    """
+    Word Error Rate, basically defined as::
+
+        insertions + deletions + substitions
+        ------------------------------------
+             number of reference words
+
+    See: https://en.wikipedia.org/wiki/Levenshtein_distance
+
+    Calculates minimum edit distance using the Levenshtein 
+    distance. This implementation uses the Editdistance, c++
+    implementation by Hiroyuki Tanaka:
+    https://github.com/aflc/editdistance
+    
+    """
+
+    def compare(self, ref: Schema, hyp: Schema):
+        ref_list = [i['item'] for i in ref]
+        total_ref = len(ref_list)
+        if total_ref == 0:
+            return 1
+        return editdistance.eval(ref_list, [i['item'] for i in hyp]) / total_ref
+        
 
 class DiffCounts(Base):
     """

--- a/src/benchmarkstt/metrics/core.py
+++ b/src/benchmarkstt/metrics/core.py
@@ -81,20 +81,22 @@ class WER(Base):
 
     See: https://en.wikipedia.org/wiki/Word_error_rate
 
-    Mode: 'levenshtein' 
-    See: https://en.wikipedia.org/wiki/Levenshtein_distance
-    Calculates minimum edit distance using the Levenshtein 
-    distance. This implementation uses the Editdistance, c++
-    implementation by Hiroyuki Tanaka:
-    https://github.com/aflc/editdistance
+    Calculates the WER using one of two algorithms:
 
-    Mode: 'strict' or 'hunt'
-    Insertions, deletions and substitutions are
-    identified using the Hunt–McIlroy diff algorithm.
-    This algorithm is the one used internally by Python.
+    [Mode: 'strict' or 'hunt'] Insertions, deletions and
+    substitutions are identified using the Hunt–McIlroy
+    diff algorithm. The 'hunt' mode applies 0.5 weight to
+    insertions and deletions. This algorithm is the one
+    used internally by Python.
     See https://docs.python.org/3/library/difflib.html
 
-    :param mode: WER variant. 'strict' is the default. 'hunt' applies 0.5 weight to insertions and deletions. 'levenshtein' is the minimum edit distance.
+    [Mode: 'levenshtein'] The Levenshtein distance is the
+    minimum edit distance. This implementation uses the
+    Editdistance, c++ implementation by Hiroyuki Tanaka:
+    https://github.com/aflc/editdistance.
+    See: https://en.wikipedia.org/wiki/Levenshtein_distance
+
+    :param mode: 'strict' (default), 'hunt' or 'levenshtein'.
     :param differ_class: For future use.
     """
 

--- a/tests/benchmarkstt/test_metrics_core.py
+++ b/tests/benchmarkstt/test_metrics_core.py
@@ -24,16 +24,17 @@ def test_diffcounts(a, b, exp):
 
 @pytest.mark.parametrize('a,b,exp', [
     # (strict_wer, hunt_wer)
-    ['aa bb cc dd', 'aa bb cc dd', (0, 0)],
-    ['aa bb cc dd', 'aa bb ee dd', (.25, .25)],
-    ['aa bb cc dd', 'aa aa bb cc dd dd', (.5, .25)],
-    ['aa bb cc dd', '', (1, 0.5)],
-    ['', 'aa bb cc', (1, 1)],
-    ['aa', 'bb aa cc', (2, 1)],
-    ['a b c d e f', 'a b d e kfmod fgdjn idf giudfg diuf dufg idgiudgd', (8/6, 3/4)],
+    ['aa bb cc dd', 'aa bb cc dd', (0, 0, 0)],
+    ['aa bb cc dd', 'aa bb ee dd', (.25, .25, .25)],
+    ['aa bb cc dd', 'aa aa bb cc dd dd', (.5, .25, .5)],
+    ['aa bb cc dd', '', (1, 0.5, 1)],
+    ['', 'aa bb cc', (1, 1, 1)],
+    ['aa', 'bb aa cc', (2, 1, 2)],
+    ['a b c d e f', 'a b d e kfmod fgdjn idf giudfg diuf dufg idgiudgd', (8/6, 3/4, 8/6)],
 ])
 def test_wer(a, b, exp):
-    wer_strict, wer_hunt = exp
+    wer_strict, wer_hunt, wer_levenshtein = exp
 
     assert WER(mode=WER.MODE_STRICT).compare(PlainText(a), PlainText(b)) == wer_strict
     assert WER(mode=WER.MODE_HUNT).compare(PlainText(a), PlainText(b)) == wer_hunt
+    assert WER(mode=WER.MODE_LEVENSHTEIN).compare(PlainText(a), PlainText(b)) == wer_levenshtein

--- a/tests/benchmarkstt/test_metrics_core.py
+++ b/tests/benchmarkstt/test_metrics_core.py
@@ -31,6 +31,7 @@ def test_diffcounts(a, b, exp):
     ['', 'aa bb cc', (1, 1, 1)],
     ['aa', 'bb aa cc', (2, 1, 2)],
     ['a b c d e f', 'a b d e kfmod fgdjn idf giudfg diuf dufg idgiudgd', (8/6, 3/4, 8/6)],
+    ['a b c d e f g h i j', 'a b e d c f g h i j', (.4, .2, .2)],
 ])
 def test_wer(a, b, exp):
     wer_strict, wer_hunt, wer_levenshtein = exp

--- a/tests/benchmarkstt/test_metrics_core.py
+++ b/tests/benchmarkstt/test_metrics_core.py
@@ -23,7 +23,7 @@ def test_diffcounts(a, b, exp):
 
 
 @pytest.mark.parametrize('a,b,exp', [
-    # (strict_wer, hunt_wer)
+    # (wer_strict, wer_hunt, wer_levenshtein)
     ['aa bb cc dd', 'aa bb cc dd', (0, 0, 0)],
     ['aa bb cc dd', 'aa bb ee dd', (.25, .25, .25)],
     ['aa bb cc dd', 'aa aa bb cc dd dd', (.5, .25, .5)],


### PR DESCRIPTION
Implements Levenshtein distance as a WER metric, as agreed in meeting on November 26th. to be used as a mode of the `--wer` function of the metrics module. The `levenshtein` mode can be used instead of the `strict` (still default) and `hunt` modes. Tests are also added in parallel to test of other `--wer` modes.