### PR TITLE
Character error rate

### DIFF
--- a/src/benchmarkstt/metrics/core.py
+++ b/src/benchmarkstt/metrics/core.py
@@ -144,6 +144,51 @@ class WER(Metric):
         return changes / total_ref
 
 
+class CER(Metric):
+    """
+    Character Error Rate, basically defined as::
+
+        insertions + deletions + substitions
+        ------------------------------------
+           number of reference characters
+
+    Character error rate, CER, compare the differences
+    between reference and hypothesis on a character level.
+    A CER measure is usually lower than WER measure, since
+    words might differ on only one or a few characters, and
+    be classified as fully different.
+
+    The CER metric might be useful as a perspective on the
+    WER metric. Word endings might be less relevant if the
+    text will be preprocessed with stemming, or minor
+    spelling mistakes might be acceptable in certain
+    situations. A CER metric might also be used to evaluate
+    a source (an ASR) which output a stream of characters
+    rather than words.
+
+    Important: The current implementation of the CER metric
+    ignores whitespace characters. A string like 'aa bb cc'
+    will first be split into words, ['aa','bb','cc'], and
+    then merged into a final string for evaluation: 'aabbcc'.
+
+    :param mode: 'levenshtein' (default).
+    :param differ_class: For future use.
+    """
+
+    # CER modes
+    MODE_LEVENSHTEIN = 'levenshtein'
+
+    def __init__(self, mode=None, differ_class=None):
+        self._mode = mode
+
+    def compare(self, ref: Schema, hyp: Schema):
+        ref_str = ''.join([i['item'] for i in ref])
+        total_ref = len(ref_str)
+        if total_ref == 0:
+            return 1
+        return editdistance.eval(ref_str, ''.join([i['item'] for i in hyp])) / total_ref
+
+
 class DiffCounts(Metric):
     """
     Get the amount of differences between reference and hypothesis

--- a/src/benchmarkstt/metrics/core.py
+++ b/src/benchmarkstt/metrics/core.py
@@ -127,7 +127,7 @@ class WER(Metric):
             ref_list = [i['item'] for i in ref]
             total_ref = len(ref_list)
             if total_ref == 0:
-                return 1
+                return 0 if len(hyp) == 0 else 1
             return editdistance.eval(ref_list, [i['item'] for i in hyp]) / total_ref
 
         diffs = get_differ(ref, hyp, differ_class=self._differ_class)
@@ -140,7 +140,7 @@ class WER(Metric):
 
         total_ref = counts.equal + counts.replace + counts.delete
         if total_ref == 0:
-            return 1
+            return 0 if len(hyp) == 0 else 1
         return changes / total_ref
 
 
@@ -185,13 +185,9 @@ class CER(Metric):
         ref_str = ''.join([i['item'] for i in ref])
         hyp_str = ''.join([i['item'] for i in hyp])
         total_ref = len(ref_str)
-        total_hyp = len(hyp_str)
 
         if total_ref == 0:
-            if total_hyp == 0:
-                return 0
-            else:
-                return 1
+            return 0 if len(hyp_str) == 0 else 1
 
         return editdistance.eval(ref_str, hyp_str) / total_ref
 

--- a/src/benchmarkstt/metrics/core.py
+++ b/src/benchmarkstt/metrics/core.py
@@ -148,9 +148,9 @@ class CER(Metric):
     """
     Character Error Rate, basically defined as::
 
-        insertions + deletions + substitions
-        ------------------------------------
-           number of reference characters
+        insertions + deletions + substitutions
+        --------------------------------------
+            number of reference characters
 
     Character error rate, CER, compare the differences
     between reference and hypothesis on a character level.
@@ -183,10 +183,17 @@ class CER(Metric):
 
     def compare(self, ref: Schema, hyp: Schema):
         ref_str = ''.join([i['item'] for i in ref])
+        hyp_str = ''.join([i['item'] for i in hyp])
         total_ref = len(ref_str)
+        total_hyp = len(hyp_str)
+
         if total_ref == 0:
-            return 1
-        return editdistance.eval(ref_str, ''.join([i['item'] for i in hyp])) / total_ref
+            if total_hyp == 0:
+                return 0
+            else:
+                return 1
+
+        return editdistance.eval(ref_str, hyp_str) / total_ref
 
 
 class DiffCounts(Metric):

--- a/src/benchmarkstt/metrics/core.py
+++ b/src/benchmarkstt/metrics/core.py
@@ -125,10 +125,11 @@ class WER(Metric):
     def compare(self, ref: Schema, hyp: Schema) -> float:
         if self._mode == self.MODE_LEVENSHTEIN:
             ref_list = [i['item'] for i in ref]
+            hyp_list = [i['item'] for i in hyp]
             total_ref = len(ref_list)
             if total_ref == 0:
-                return 0 if len(hyp) == 0 else 1
-            return editdistance.eval(ref_list, [i['item'] for i in hyp]) / total_ref
+                return 0 if len(hyp_list) == 0 else 1
+            return editdistance.eval(ref_list, hyp_list) / total_ref
 
         diffs = get_differ(ref, hyp, differ_class=self._differ_class)
 
@@ -138,10 +139,10 @@ class WER(Metric):
             counts.delete * self.DEL_PENALTY + \
             counts.insert * self.INS_PENALTY
 
-        total_ref = counts.equal + counts.replace + counts.delete
-        if total_ref == 0:
-            return 0 if len(hyp) == 0 else 1
-        return changes / total_ref
+        total = counts.equal + counts.replace + counts.delete
+        if total == 0:
+            return 0
+        return changes / total
 
 
 class CER(Metric):

--- a/src/benchmarkstt/metrics/core.py
+++ b/src/benchmarkstt/metrics/core.py
@@ -141,7 +141,7 @@ class WER(Metric):
 
         total = counts.equal + counts.replace + counts.delete
         if total == 0:
-            return 0
+            return 1 if changes else 0
         return changes / total
 
 

--- a/tests/benchmarkstt/test_metrics_core.py
+++ b/tests/benchmarkstt/test_metrics_core.py
@@ -1,4 +1,4 @@
-from benchmarkstt.metrics.core import DiffCounts, WER
+from benchmarkstt.metrics.core import DiffCounts, WER, CER
 from benchmarkstt.metrics.core import OpcodeCounts
 from benchmarkstt.input.core import PlainText
 import pytest
@@ -39,3 +39,21 @@ def test_wer(a, b, exp):
     assert WER(mode=WER.MODE_STRICT).compare(PlainText(a), PlainText(b)) == wer_strict
     assert WER(mode=WER.MODE_HUNT).compare(PlainText(a), PlainText(b)) == wer_hunt
     assert WER(mode=WER.MODE_LEVENSHTEIN).compare(PlainText(a), PlainText(b)) == wer_levenshtein
+
+
+@pytest.mark.parametrize('a,b,exp', [
+    # (cer_levenshtein)
+    ['aa bb cc dd', 'aa bb cc dd', (0,)],
+    ['aa bb cc dd', 'aa bb ee dd', (2/8,)],
+    ['aa bb cc dd', 'aabb ec dd', (1/8,)],
+    ['aa bb cc dd', 'aa aa bb cc dd dd', (4/8,)],
+    ['aa bb cc dd', '', (1,)],
+    ['', 'aa bb cc', (1,)],
+    ['aa', 'bb aa cc', (4/2,)],
+    ['a b c d e f', 'a b d e kfmod', (5/6,)],
+    ['a b c d e f g h i j', 'abedcfghij', (.2,)],
+])
+def test_cer(a, b, exp):
+    cer_levenshtein, = exp
+
+    assert CER(mode=CER.MODE_LEVENSHTEIN).compare(PlainText(a), PlainText(b)) == cer_levenshtein


### PR DESCRIPTION
Implements a character error rate metric as discussed in issue #132.

The metric is implemented as a parallel to `--wer`, as `--cer`. It has one _mode_, which is 'levensthein' aka minimum edit distance.

This is a first step suggestion, since the metric ignore differences in whitespaces. (The reason for this is also described in the issue.) It's not necessarily a problem, but might be a matter of choice, but it seems important to be explicit about this behaviour. Is that clear enough from the explanation in the docs, or do we need an example there too?

A new test is also implemented.