### PR TITLE
Entity error rate

### DIFF
--- a/src/benchmarkstt/metrics/core.py
+++ b/src/benchmarkstt/metrics/core.py
@@ -253,7 +253,7 @@ class BEER(Metric):
             if elt == entity[cursor]:
                 cursor += 1
                 if cursor == le:
-                    idx_found.append([idx for idx in range(idx_sl - le + 1, idx_sl - le + 1 + le)])
+                    idx_found.append(list(range(idx_sl - le + 1, idx_sl - le + 1 + le)))
                     cursor = 0
             else:
                 cursor = 0

--- a/src/benchmarkstt/metrics/core.py
+++ b/src/benchmarkstt/metrics/core.py
@@ -187,6 +187,19 @@ class BEER(Metric):
     and
     w_1 + ... + w_N = 1
 
+    The input file defines the list of entities and the weight per entity, w_n. It has be a json file with the
+    following structure:
+
+    { "entity_1":W1, "entity_2" : W2, "entity_3" :W3 .. }
+
+    W_n being the non-normalized weight, the noramlisation of the weights is performed by the tool as :
+
+                W_n
+    w_n =  ---------------
+            W_1 + ... +W_1
+
+    The minimum value for weight being 0.
+
     """
     def __init__(self, entities_file=''):
         """

--- a/src/benchmarkstt/metrics/core.py
+++ b/src/benchmarkstt/metrics/core.py
@@ -280,14 +280,14 @@ class BEER(Metric):
                 beer_entity = round(abs(count_ref - count_hypothesis) / count_ref, 3)
                 # accumulate the distance per entity
                 beer_av += abs(count_ref - count_hypothesis) * self._weight[idx]
-            beer[entity] = {'beer': beer_entity, 'occurence_ref': count_ref}
+            beer[entity] = {'beer': beer_entity, 'occurrence_ref': count_ref}
 
         l_ref = len(list_reference_entity)
         if l_ref > 0:
             beer_av = round(beer_av / l_ref, 3)
         else:
             beer_av = 0
-        beer['w_av_beer'] = {'beer': beer_av, 'occurence_ref': l_ref}
+        beer['w_av_beer'] = {'beer': beer_av, 'occurrence_ref': l_ref}
         return beer
 
     def compare(self, ref: Schema, hyp: Schema):

--- a/src/benchmarkstt/metrics/core.py
+++ b/src/benchmarkstt/metrics/core.py
@@ -187,36 +187,27 @@ class BEER(Metric):
     and
     w_1 + ... + w_N = 1
 
-    [Mode: 'weighted_bag_of_words'] defined the way the averaged BEER is computed with weighting factors w_i defined in
-    the json file
-
     """
-    # average BEER modes
-    MODE_WEIGHTED_BAG_OF_WORDS = 'weighted_bag_of_words'
-
-    def __init__(self, entities_file='', mode=None):
+    def __init__(self, entities_file=''):
         """
         """
-        self._mode = mode
         self._weight = []
         self._entities = []
 
-        if mode == self.MODE_WEIGHTED_BAG_OF_WORDS:
-            self.out_name = 'w_av_beer'
+        if entities_file.endswith('.json'):
+            with open(entities_file) as f:
+                data = json.load(f)
+            self._entities = list(data.keys())
+            weight = list(data.values())
+            weight = [0 if w < 0 else w for w in weight]
 
-            if entities_file.endswith('.json'):
-                with open(entities_file) as f:
-                    data = json.load(f)
-                self._entities = list(data.keys())
-                weight = list(data.values())
-                weight = [0 if w < 0 else w for w in weight]
+            # normalized the sum of the weights to 1
+            # after assignment when the file is not red
+            sw = sum(weight)
+            if sw > 0:
+                self._weight = [w / sw for w in weight]
+            return
 
-                # normalized the sum of the weights to 1
-                # after assignment when the file is not red
-                sw = sum(weight)
-                if sw > 0:
-                    self._weight = [w / sw for w in weight]
-                return
         return
 
     def get_weight(self):
@@ -296,7 +287,7 @@ class BEER(Metric):
             beer_av = round(beer_av / l_ref, 3)
         else:
             beer_av = 0
-        beer[self.out_name] = {'beer': beer_av, 'occurence_ref': l_ref}
+        beer['w_av_beer'] = {'beer': beer_av, 'occurence_ref': l_ref}
         return beer
 
     def compare(self, ref: Schema, hyp: Schema):

--- a/src/benchmarkstt/metrics/core.py
+++ b/src/benchmarkstt/metrics/core.py
@@ -136,8 +136,8 @@ class WER(Metric):
         counts = get_opcode_counts(diffs.get_opcodes())
 
         changes = counts.replace * self.SUB_PENALTY \
-            + counts.delete * self.DEL_PENALTY \
-            + counts.insert * self.INS_PENALTY
+                  + counts.delete * self.DEL_PENALTY \
+                  + counts.insert * self.INS_PENALTY
 
         total_ref = counts.equal + counts.replace + counts.delete
         if total_ref == 0:
@@ -203,21 +203,24 @@ class BEER(Metric):
     The minimum value for weight being 0.
 
     """
+
     def __init__(self, entities_file=''):
         """
         """
-        self._weight = []
-        self._entities = []
-
+        # remove
+        # self._entities_file = entities_file
         try:
             with open(entities_file) as f:
                 data = json.load(f)
-            self._entities = list(data.keys())
-            weight = list(data.values())
-            self.set_weight(weight)
-        except IOError:
-            print('Input file Error')
-
+                self._entities = list(data.keys())
+                weight = list(data.values())
+                self.set_weight(weight)
+        except:
+            # generate an empty dict as output
+            # self._weight = []
+            # self._entities = []
+            # or an error
+            print('Error: invalid file ...')
         return
 
     def get_weight(self):
@@ -245,18 +248,19 @@ class BEER(Metric):
         # the cursor sweep complex_entity to find consecutive entities entity1 ... entity2
         cursor = 0
         idx_found = []
-        for idx, elt in enumerate(search_list):
+        for idx_sl, elt in enumerate(search_list):
             if elt == entity[cursor]:
                 cursor += 1
                 if cursor == le:
-                    idx_found.append([idx for idx in range(idx - le + 1, idx - le + 1 + le)])
+                    idx_found.append([idx for idx in range(idx_sl - le + 1, idx_sl - le + 1 + le)])
+                    # idx_found.append(list(range(idx - le + 1, idx - le + 1 + le)))
                     cursor = 0
             else:
                 cursor = 0
         return idx_found
 
     # generate a list containing the detected entities in list_parsed
-    @staticmethod
+    # @staticmethod
     def __generate_list_entity(self, list_parsed):
 
         list_entity = []
@@ -276,7 +280,7 @@ class BEER(Metric):
         return list_entity
 
     # computes the BEER
-    @staticmethod
+    # @staticmethod
     def compute_beer(self, list_hypothesis_entity, list_reference_entity):
         beer = {}
         beer_av = 0
@@ -300,15 +304,25 @@ class BEER(Metric):
         return beer
 
     def compare(self, ref: Schema, hyp: Schema):
+
+        # try:
+        #    with open(self._entities_file) as f:
+        #        data = json.load(f)
+        #    self._entities = list(data.keys())
+        #    weight = list(data.values())
+        #    self.set_weight(weight)
+        # except (IOError, json.decoder.JSONDecodeError):
+        #    print('BEER input file Error')
+
         # get the list of reference and hypothesis
         ref_list = [i['item'] for i in ref]
         hyp_list = [i['item'] for i in hyp]
 
         # extract the entities
-        list_hypothesis_entity = self.__generate_list_entity(self, hyp_list)
-        list_reference_entity = self.__generate_list_entity(self, ref_list)
+        list_hypothesis_entity = self.__generate_list_entity(hyp_list)
+        list_reference_entity = self.__generate_list_entity(ref_list)
         # compute the score
-        wer_entity = self.compute_beer(self, list_hypothesis_entity, list_reference_entity)
+        wer_entity = self.compute_beer(list_hypothesis_entity, list_reference_entity)
         return wer_entity
 
 # For a future version

--- a/src/benchmarkstt/metrics/core.py
+++ b/src/benchmarkstt/metrics/core.py
@@ -214,7 +214,6 @@ class BEER(Metric):
         return self._weight
 
     def set_weight(self, weight):
-
         weight = [0 if w < 0 else w for w in weight]
         sw = sum(weight)
         if sw > 0:
@@ -291,14 +290,9 @@ class BEER(Metric):
         return beer
 
     def compare(self, ref: Schema, hyp: Schema):
-
+        # get the list of reference and hypothesis
         ref_list = [i['item'] for i in ref]
-        total_ref = len(ref_list)
-        if total_ref == 0:
-            return 1
         hyp_list = [i['item'] for i in hyp]
-
-        # entities = self._entities
 
         # extract the entities
         list_hypothesis_entity = self.__generate_list_entity(self, hyp_list)

--- a/tests/benchmarkstt/test_metrics_core.py
+++ b/tests/benchmarkstt/test_metrics_core.py
@@ -62,5 +62,6 @@ def test_beer(a, b, entities_list, weights, exp):
     out = beer_test.compare(PlainText(a), PlainText(b))
     entities_list.append('w_av_beer')
 
-    assert tuple(out['w_av_beer'].values()) == exp
     assert set(out.keys()) == set(entities_list)
+    assert out['w_av_beer']['beer'] == exp[0]
+    assert out['w_av_beer']['occurrence_ref'] == exp[1]

--- a/tests/benchmarkstt/test_metrics_core.py
+++ b/tests/benchmarkstt/test_metrics_core.py
@@ -60,6 +60,7 @@ def test_beer(a, b, entities_list, weights, exp):
     beer_test.set_entities(entities_list)
     beer_test.set_weight(weights)
     out = beer_test.compare(PlainText(a), PlainText(b))
+    entities_list.append('w_av_beer')
 
     assert tuple(out['w_av_beer'].values()) == exp
-    assert list(out.keys())[0:2] == entities_list
+    assert set(out.keys()) == set(entities_list)

--- a/tests/benchmarkstt/test_metrics_core.py
+++ b/tests/benchmarkstt/test_metrics_core.py
@@ -54,7 +54,7 @@ def test_wer(a, b, exp):
 ])
 def test_beer(a, b, entities_list, weights, exp):
 
-    beer_test = BEER(mode=BEER.MODE_WEIGHTED_BAG_OF_WORDS)
+    beer_test = BEER()
     beer_test.set_entities(entities_list)
     beer_test.set_weight(weights)
     out = beer_test.compare(PlainText(a), PlainText(b))

--- a/tests/benchmarkstt/test_metrics_core.py
+++ b/tests/benchmarkstt/test_metrics_core.py
@@ -43,6 +43,7 @@ def test_wer(a, b, exp):
 
 @pytest.mark.parametrize('a,b,entities_list,weights, exp', [
     ['madam is here', 'adam is here', ['madam', 'here'], [100, 10], (0.455, 2)],
+    ['madam is here', 'adam is here', ['madam', 'here'], [0.9, 0.1], (0.450, 2)],
     ['madam is here', 'adam is here', ['madam', 'here'], [10, 100], (0.045, 2)],
     ['theresa may is here', 'theresa may is there', ['theresa may', 'here'], [10, 100], (0.455, 2)],
     ['theresa may is here', 'theresa may is there', ['theresa may', 'here'], [100, 10], (0.045, 2)],
@@ -51,6 +52,7 @@ def test_wer(a, b, exp):
     ['aa bb cc dd', 'aa bb cc dd ee ff gg hh', ['aa', 'ee'], [10, 100], (0.0, 1)],
     ['aa bb cc dd', 'aa bb cc d ee ff gg hh', ['aa bb', 'cc dd'], [100, 10], (0.045, 2)],
     ['aa bb cc dd', 'aa bb cc d ee ff gg hh', ['aa bb', 'cc dd'], [10, 100], (0.455, 2)],
+    ['', 'aa bb cc d ee ff gg hh', ['aa bb', 'cc dd'], [10, 100], (0.000, 0)],
 ])
 def test_beer(a, b, entities_list, weights, exp):
 

--- a/tests/benchmarkstt/test_metrics_core.py
+++ b/tests/benchmarkstt/test_metrics_core.py
@@ -53,6 +53,9 @@ def test_wer(a, b, exp):
     ['aa bb cc dd', 'aa bb cc d ee ff gg hh', ['aa bb', 'cc dd'], [100, 10], (0.045, 2)],
     ['aa bb cc dd', 'aa bb cc d ee ff gg hh', ['aa bb', 'cc dd'], [10, 100], (0.455, 2)],
     ['', 'aa bb cc d ee ff gg hh', ['aa bb', 'cc dd'], [10, 100], (0.000, 0)],
+    ['', '', ['aa bb', 'cc dd'], [10, 100], (0.000, 0)],
+    ['aa bb c', '', ['aa bb', 'cc dd'], [0.9, 0.1], (0.9, 1)],
+
 ])
 def test_beer(a, b, entities_list, weights, exp):
 


### PR DESCRIPTION
Implements a new metric called the weighted average bag of entity error rate: WA_BEER as discussed in [#115 ](https://github.com/ebu/benchmarkstt/issues/115)

The metric is implemented as an extension of --wer:  
--beer entities.json -o json
with entities.json file defined as : 
{ "entitie_1": w_1, "entitie_2" : w_2... }

entitie_n being the entity n, defined as a list of words
the w_1 is the weight defining the importance of entity 1 for the computation of the weighted average beer, WA_BEER.

The output is a json file : 

{ entity_1: {'beer':  x1, 'occurrence_ref': n1}
entity_2: {'beer': x2, 'occurrence_ref': n2}
entity_3: {'beer': x3, 'occurrence_ref': n3}
w_av_beer: {'beer': wa_1, 'occurrence_ref': n1+n2+n3} }

with:

entity_i : text string defining entity_1
x_i : is the beer of entity i
n_i : is the number of occurrences of entity_i in the reference file
w_av_beer is the weighted average beer

A new test is implemented.
 